### PR TITLE
feature/RED-751: Passes mobile and desktop as context variables to the app

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -9,9 +9,11 @@ function defaultErrorHandler(err, req, res, next) {
 }
 
 function getContext(req) {
-  const fullUrl = `${req.protocol}://${req.get("host")}${req.originalUrl}`;
   const url = req.originalUrl;
-  return { url, fullUrl };
+  const fullUrl = `${req.protocol}://${req.get("host")}${req.originalUrl}`;
+  const mobile = req.subdomains.indexOf("m") !== -1;
+  const desktop = req.subdomains.indexOf("m") === -1;
+  return { url, fullUrl, mobile, desktop };
 }
 
 module.exports = (render, errorHandler = defaultErrorHandler) => async (req, res, next) => {


### PR DESCRIPTION
This pull request adds 2 booleans to the context that will be passed to the application as $appContext:

```js
{
  mobile: true, // or false
  desktop: false, // or true
}
```

these booleans are mutually exclusive. One is always false, the other is then always true.

To detect the context this PR simply checks if `m` is a subdomain. I write 'a' subdomain, because not only

m.bild.de

will be detected as mobile, but also

something.m.bild.de
m.something.bild.de
www.m.bild.de
m.www.bild.de

if there is an `m` it's mobile, if not it's desktop. I am not sure if this is the desired behavior though, please let us discuss this. Who would know this?