### PR TITLE
Disables host check on the dev server

### DIFF
--- a/lib/build/webpack.config.server.dev.js
+++ b/lib/build/webpack.config.server.dev.js
@@ -7,4 +7,5 @@ module.exports = {
   compress: false,
   overlay: true,
   quiet: true,
+  disableHostCheck: true,
 };


### PR DESCRIPTION
This enables us to write 

```
127.0.0.1	www.bild.de
127.0.0.1	m.bild.de
127.0.0.1	bild.de
```

in our `/etc/hosts` so we can test with proper domains (and test the context most importantly)