### PR TITLE
updated vue-svg-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url-loader": "1.1.1",
     "vue-loader": "15.4.2",
     "vue-server-renderer": "2.5.17",
-    "vue-svg-loader": "0.8.0",
+    "vue-svg-loader": "0.12.0",
     "vue-template-compiler": "2.5.17",
     "webpack": "4.19.1",
     "webpack-dev-server": "3.1.8",


### PR DESCRIPTION
updated vue svg loader due to an error in the old version 

vue svg loader loaded the latest cue template compiler but we need 2.5.17 for our project. (yarn serve --> compilation failed)

```
vue packages version mismatch:

- vue@2.5.17
- vue-template-compiler@2.6.5

This may cause things to work incorrectly. Make sure to use the same version for both.
If you are using vue-loader@>=10.0, simply update vue-template-compiler.
If you are using vue-loader@<10.0 or vueify, re-installing vue-loader/vueify should bump vue-template-compiler to the latest.
```