### PR TITLE
Escaped public path with quotation marks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vussr",
   "description": "✊ VUSSR—Server Side Rendering for VUE",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "ISC",
   "main": "index.js",
   "bin": {

--- a/webpack/webpack.config.devServer.js
+++ b/webpack/webpack.config.devServer.js
@@ -13,7 +13,6 @@ const transformSlashes = val => val.replace(/\\/, '/').replace(/^\/?/, '/').repl
 const relativePath = val => transformSlashes(testSpaces(path.relative(process.cwd(), val)));
 
 module.exports = function getDevServerConfig(config) {
-  console.log(relativePath(config.assetsPath));
   return {
     contentBase: [config.outputPath, config.assetsPath],
     publicPath: relativePath(config.assetsPath),

--- a/webpack/webpack.config.devServer.js
+++ b/webpack/webpack.config.devServer.js
@@ -1,13 +1,22 @@
+const path = require('path');
+
+/**
+ * Transforming the public path to an relative path and check if it contains
+ * space symbols. This is a workaround because publicPath can't handle a path
+ * with spaces inside. This applies for unescaped as well escaped space characters.
+ * On the other hand all other configured path values for the webpack dev server
+ * should be absolute and can't handle an absoulte path escaped by quotation marks.
+ **/
+const exceptionMsg = val => `Spaces are not allowed inside the WebPack publicPath: ${val}`;
+const testSpaces = val => { if (/\s/.test(val)) { throw new Error(exceptionMsg(val))} return val };
+const transformSlashes = val => val.replace(/\\/, '/').replace(/^\/?/, '/').replace(/\/?$/, '/');
+const relativePath = val => transformSlashes(testSpaces(path.relative(process.cwd(), val)));
+
 module.exports = function getDevServerConfig(config) {
+  console.log(relativePath(config.assetsPath));
   return {
     contentBase: [config.outputPath, config.assetsPath],
-    /**
-     * Workaround because publicPath can't handle a path with spaces inside.
-     * This applies for unecaped as well escaped space characters.
-     * On the other hand all other configured path values for the webpack dev server
-     * can't handle an absoulte path escaped by quotation marks.
-     **/
-    publicPath: `"${config.assetsPath}"`,
+    publicPath: relativePath(config.assetsPath),
     port: 8080,
     compress: false,
     overlay: true,

--- a/webpack/webpack.config.devServer.js
+++ b/webpack/webpack.config.devServer.js
@@ -1,7 +1,13 @@
 module.exports = function getDevServerConfig(config) {
   return {
     contentBase: [config.outputPath, config.assetsPath],
-    publicPath: config.assetsPath,
+    /**
+     * Workaround because publicPath can't handle a path with spaces inside.
+     * This applies for unecaped as well escaped space characters.
+     * On the other hand all other configured path values for the webpack dev server
+     * can't handle an absoulte path escaped by quotation marks.
+     **/
+    publicPath: `"${config.assetsPath}"`,
     port: 8080,
     compress: false,
     overlay: true,


### PR DESCRIPTION
Currently the Webpack Dev Server will fail if the absolute directory path for the 'publicPath' configuration key contains spaces. This PR fixes that problem.