### PR TITLE
Fixed untranspiled JS produced by vue-svg-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vussr",
   "description": "✊ VUSSR—Server Side Rendering for VUE",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "license": "ISC",
   "main": "index.js",
   "bin": {

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -80,7 +80,7 @@ module.exports = function getBaseConfig(config) {
         },
         {
           test: /\.svg$/,
-          loader: 'vue-svg-loader',
+          use: ['babel-loader', 'vue-svg-loader'],
         },
         {
           test: /\.txt$/,


### PR DESCRIPTION
vue-svg-loader turns SVG files into JS files (Vue components), but the default VUSSR Webpack config doesn't transpile that JS code. This PR fixes that.