### PR TITLE
Expose Webpack merge to consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vussr",
   "description": "✊ VUSSR—Server Side Rendering for VUE",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "ISC",
   "main": "index.js",
   "bin": {

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,5 +1,6 @@
+const merge = require('webpack-merge');
 const client = require('./webpack.config.client');
 const server = require('./webpack.config.server');
 const devServer = require('./webpack.config.devServer');
 
-module.exports = { client, server, devServer };
+module.exports = { client, server, devServer, merge };


### PR DESCRIPTION
Right now, when extending VUSSR's default config in `vussr.config.js`, users have to modify the default config object and extend it with their changes, e. g.:

```js
module.exports = {
    client: defaultConfig => {
        defaultConfig.module.rules.push(myExtraRule);
        return defaultConfig;
    }
};
```

This PR enables the use of webpack-merge to solve this more elegantly:

```js
const { merge } = require('vussr/webpack');

module.exports = {
    client: defaultConfig => merge(defaultConfig, myExtraConfig)
};
```