### PR TITLE
RED-1649: added and configured svg inline loader

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+--install.frozen-lockfile true
+--add.exact true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vussr",
   "description": "✊ VUSSR—Server Side Rendering for VUE",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "license": "ISC",
   "main": "index.js",
   "bin": {
@@ -46,7 +46,7 @@
     "pretty-error": "2.1.1",
     "raw-loader": "0.5.1",
     "sass-loader": "7.1.0",
-    "svg-inline-loader": "^0.8.0",
+    "svg-inline-loader": "0.8.0",
     "url-loader": "1.1.1",
     "vue-loader": "15.4.2",
     "vue-server-renderer": "2.5.17",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "pretty-error": "2.1.1",
     "raw-loader": "0.5.1",
     "sass-loader": "7.1.0",
+    "svg-inline-loader": "^0.8.0",
     "url-loader": "1.1.1",
     "vue-loader": "15.4.2",
     "vue-server-renderer": "2.5.17",

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -80,7 +80,19 @@ module.exports = function getBaseConfig(config) {
         },
         {
           test: /\.svg$/,
-          use: ['babel-loader', 'vue-svg-loader'],
+          oneOf: [
+            {
+              resourceQuery: /component/,
+              use: ['babel-loader', 'vue-svg-loader'],
+            },
+            {
+
+              use: {
+                loader: 'svg-inline-loader',
+                options: { removeSVGTagAttrs: false },
+              },
+            },
+          ]
         },
         {
           test: /\.txt$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7769,7 +7769,7 @@ supports-color@^5.1.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-co
   dependencies:
     has-flag "^3.0.0"
 
-svg-inline-loader@^0.8.0:
+svg-inline-loader@0.8.0:
   version "0.8.0"
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/svg-inline-loader/-/svg-inline-loader-0.8.0.tgz#7e9d905d80d0b4e68d2df21afcd08ee9e9a3ea6e"
   integrity sha1-fp2QXYDQtOaNLfIa/NCO6emj6m4=

--- a/yarn.lock
+++ b/yarn.lock
@@ -5124,7 +5124,7 @@ loader-runner@^2.3.0:
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/loader-runner/-/loader-runner-2.3.1.tgz#026f12fe7c3115992896ac02ba022ba92971b979"
   integrity sha1-Am8S/nwxFZkolqwCugIrqSlxuXk=
 
-loader-utils@^0.2.16:
+loader-utils@^0.2.11, loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
@@ -7323,6 +7323,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+simple-html-tokenizer@^0.1.1:
+  version "0.1.1"
+  resolved "https://spring.jfrog.io/spring/api/npm/npm-red/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
+  integrity sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -7763,6 +7768,15 @@ supports-color@^5.1.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-co
   integrity sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=
   dependencies:
     has-flag "^3.0.0"
+
+svg-inline-loader@^0.8.0:
+  version "0.8.0"
+  resolved "https://spring.jfrog.io/spring/api/npm/npm-red/svg-inline-loader/-/svg-inline-loader-0.8.0.tgz#7e9d905d80d0b4e68d2df21afcd08ee9e9a3ea6e"
+  integrity sha1-fp2QXYDQtOaNLfIa/NCO6emj6m4=
+  dependencies:
+    loader-utils "^0.2.11"
+    object-assign "^4.0.1"
+    simple-html-tokenizer "^0.1.1"
 
 svg-to-vue@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
As described the default svg loader was changed to the svg-inline-loader, because the vue-svg-loader brings to much overhead to the project that is mostly not needed. If the svg needs to be imported as a component `?component` can be added as a query string to the file path.