### PR TITLE
Adjusted filenames to include content hashes

### DIFF
--- a/src/vussr.config.default.js
+++ b/src/vussr.config.default.js
@@ -10,7 +10,7 @@ module.exports = {
   template: resolveApp('public/index.html'),
   outputPath: resolveApp('dist'),
   assetsPath: resolveApp('dist/assets'),
-  filename: '[name].[chunkhash].js',
+  filename: '[name].[contenthash:8].js',
   middleware: { before: [], after: [] },
   copy: [],
   server: defaultConfig => defaultConfig,

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -62,7 +62,7 @@ module.exports = function getBaseConfig(config) {
           loader: 'url-loader',
           options: {
             limit: 4096,
-            name: `./fonts/[name].[ext]?[hash]`,
+            name: `fonts/[name].[contenthash:8].[ext]`,
           },
         },
         {
@@ -70,7 +70,7 @@ module.exports = function getBaseConfig(config) {
           loader: 'url-loader',
           options: {
             limit: 8000,
-            name: `./img/[name].[ext]?[hash]`,
+            name: `img/[name].[contenthash:8].[ext]`,
           },
         },
         {


### PR DESCRIPTION
This PR changes the file name format of script, image and font file names to include a content-based hash in their filenames, and removes the query string-based build hash from them.

This is useful to enable aggressive caching of assets.