### PR TITLE
Removed automatic data URI inlining of small assets (URL loader)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vussr",
   "description": "✊ VUSSR—Server Side Rendering for VUE",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "license": "ISC",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "raw-loader": "0.5.1",
     "sass-loader": "7.1.0",
     "svg-inline-loader": "0.8.0",
-    "url-loader": "1.1.1",
     "vue-loader": "15.4.2",
     "vue-server-renderer": "2.5.17",
     "vue-svg-loader": "0.12.0",

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -59,17 +59,15 @@ module.exports = function getBaseConfig(config) {
         },
         {
           test: /\.(woff|woff2)$/,
-          loader: 'url-loader',
+          loader: 'file-loader',
           options: {
-            limit: 4096,
             name: `fonts/[name].[contenthash:8].[ext]`,
           },
         },
         {
           test: /\.(png|jpe?g|gif)$/,
-          loader: 'url-loader',
+          loader: 'file-loader',
           options: {
-            limit: 8000,
             name: `img/[name].[contenthash:8].[ext]`,
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,7 +5508,7 @@ mime@^1.4.1:
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=
 
-mime@^2.0.3, mime@^2.3.1:
+mime@^2.3.1:
   version "2.3.1"
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
   integrity sha1-sWIcVNY7l8R9PP5/chX31kUXw2k=
@@ -8241,15 +8241,6 @@ url-join@^4.0.0:
   version "4.0.0"
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
   integrity sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=
-
-url-loader@1.1.1:
-  version "1.1.1"
-  resolved "https://spring.jfrog.io/spring/api/npm/npm-red/url-loader/-/url-loader-1.1.1.tgz#4d1f3b4f90dde89f02c008e662d604d7511167c1"
-  integrity sha1-TR87T5Dd6J8CwAjmYtYE11ERZ8E=
-  dependencies:
-    loader-utils "^1.1.0"
-    mime "^2.0.3"
-    schema-utils "^1.0.0"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The automatic inlining of small image or font files is a nice optimization, but it breaks in some scenarios.

For example, when files are being referenced in `<link>` or `<meta>` tags it is not always valid to include data URIs, and often it does not make sense to inline all files given in meta tags (and transfer them on every page load).

This PR proposes to remove the URL loader and to leave required optimizations to the user.