### PR TITLE
Enable serving of assets over a CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vussr",
   "description": "✊ VUSSR—Server Side Rendering for VUE",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "ISC",
   "main": "index.js",
   "bin": {

--- a/src/config.js
+++ b/src/config.js
@@ -2,12 +2,11 @@ const webpackConfig = require('../webpack');
 const defaultConfig = require('./vussr.config.default');
 
 class Config {
-
   constructor(config, cliOptions) {
     const nockOptions = this.getNockOptions(cliOptions);
     this.config = Object.assign({}, defaultConfig, config, nockOptions);
     this.config.isCDN = this.isUrl(this.config.assetsUrlPath);
-    if(!this.config.isCDN) {
+    if (!this.config.isCDN) {
       this.config.assetsUrlPath = this.cleanRelativePath(this.config.assetsUrlPath);
     }
   }

--- a/src/config.js
+++ b/src/config.js
@@ -2,9 +2,26 @@ const webpackConfig = require('../webpack');
 const defaultConfig = require('./vussr.config.default');
 
 class Config {
+
   constructor(config, cliOptions) {
     const nockOptions = this.getNockOptions(cliOptions);
     this.config = Object.assign({}, defaultConfig, config, nockOptions);
+    this.config.isCDN = this.isUrl(this.config.assetsUrlPath);
+    if(!this.config.isCDN) {
+      this.config.assetsUrlPath = this.cleanRelativePath(this.config.assetsUrlPath);
+    }
+  }
+
+  cleanRelativePath(val) {
+    return val.replace(/^\/?/, '/').replace(/\/?$/, '/');
+  }
+
+  isUrl(string) {
+    try {
+      return Boolean(new URL(string));
+    } catch (err) {
+      return false;
+    }
   }
 
   getJson() {

--- a/src/server.prod.js
+++ b/src/server.prod.js
@@ -46,16 +46,20 @@ class ProdServer {
     const accessLogs = this.config.accessLogs || 'clf';
     const renderFn = this.getRenderFunction();
     if (!this.config.isCDN) {
-      const serverPublicPath = this.config.server.output.publicPath;
-      const clientPublicPath = this.config.client.output.publicPath;
-      const serverOutputPath = this.config.server.output.path;
-      const clientOutputPath = this.config.client.output.path;
-      app.use(serverPublicPath, express.static(serverOutputPath));
-      app.use(clientPublicPath, express.static(clientOutputPath));
-    }
+      this.setupStaticFiles(app);
+    };
     app.use('/healthcheck', healthcheck());
     app.use(...getMiddleWares({ renderFn, before, after, nock, nockPath, accessLogs }));
     return app;
+  }
+
+  setupStaticFiles(app) {
+    const serverPublicPath = this.config.server.output.publicPath;
+    const clientPublicPath = this.config.client.output.publicPath;
+    const serverOutputPath = this.config.server.output.path;
+    const clientOutputPath = this.config.client.output.path;
+    app.use(serverPublicPath, express.static(serverOutputPath));
+    app.use(clientPublicPath, express.static(clientOutputPath));
   }
 
   getRenderFunction() {

--- a/src/server.prod.js
+++ b/src/server.prod.js
@@ -17,6 +17,14 @@ const renderOptions = {
   runInNewContext: false,
 };
 
+function isUrl(string) {
+  try {
+    return Boolean(new URL(string));
+  } catch (err) {
+    return false;
+  }
+}
+
 class ProdServer {
   constructor(config, cliOptions) {
     this.config = new Config(config, cliOptions).getJson();
@@ -49,9 +57,13 @@ class ProdServer {
     const nockPath = this.config.nockPath;
     const accessLogs = this.config.accessLogs || 'clf';
     const renderFn = this.getRenderFunction();
+    if (!isUrl(serverPublicPath)) {
+      app.use(serverPublicPath, express.static(serverOutputPath));
+    }
+    if (!isUrl(clientPublicPath)) {
+      app.use(clientPublicPath, express.static(clientOutputPath));
+    }
     app.use('/healthcheck', healthcheck());
-    app.use(serverPublicPath, express.static(serverOutputPath));
-    app.use(clientPublicPath, express.static(clientOutputPath));
     app.use(...getMiddleWares({ renderFn, before, after, nock, nockPath, accessLogs }));
     return app;
   }

--- a/src/server.prod.js
+++ b/src/server.prod.js
@@ -17,14 +17,6 @@ const renderOptions = {
   runInNewContext: false,
 };
 
-function isUrl(string) {
-  try {
-    return Boolean(new URL(string));
-  } catch (err) {
-    return false;
-  }
-}
-
 class ProdServer {
   constructor(config, cliOptions) {
     this.config = new Config(config, cliOptions).getJson();
@@ -48,19 +40,17 @@ class ProdServer {
 
   setupApp() {
     const app = express();
-    const serverPublicPath = this.config.server.output.publicPath;
-    const clientPublicPath = this.config.client.output.publicPath;
-    const serverOutputPath = this.config.server.output.path;
-    const clientOutputPath = this.config.client.output.path;
     const { before, after } = this.config.middleware;
     const nock = this.config.nock;
     const nockPath = this.config.nockPath;
     const accessLogs = this.config.accessLogs || 'clf';
     const renderFn = this.getRenderFunction();
-    if (!isUrl(serverPublicPath)) {
+    if (!this.config.isCDN) {
+      const serverPublicPath = this.config.server.output.publicPath;
+      const clientPublicPath = this.config.client.output.publicPath;
+      const serverOutputPath = this.config.server.output.path;
+      const clientOutputPath = this.config.client.output.path;
       app.use(serverPublicPath, express.static(serverOutputPath));
-    }
-    if (!isUrl(clientPublicPath)) {
       app.use(clientPublicPath, express.static(clientOutputPath));
     }
     app.use('/healthcheck', healthcheck());

--- a/src/vussr.config.default.js
+++ b/src/vussr.config.default.js
@@ -10,6 +10,7 @@ module.exports = {
   template: resolveApp('public/index.html'),
   outputPath: resolveApp('dist'),
   assetsPath: resolveApp('dist/assets'),
+  assetsUrlPath: '/assets/',
   filename: '[name].[contenthash:8].js',
   middleware: { before: [], after: [] },
   copy: [],

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -19,7 +19,7 @@ module.exports = function getBaseConfig(config) {
     context: process.cwd(),
     output: {
       path: config.assetsPath,
-      publicPath: `/${relativeAssetsPath}/`,
+      publicPath: process.env.PUBLIC_PATH || `/${relativeAssetsPath}/`,
       filename: '[name].js',
     },
     node: {

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -11,8 +11,6 @@ module.exports = function getBaseConfig(config) {
     new CleanWebpackPlugin(config.outputPath, { verbose: false }),
   ];
 
-  const relativeAssetsPath = path.relative(config.outputPath, config.assetsPath);
-
   return {
     mode: isProd ? 'production' : 'development',
     devtool: isProd ? false : 'source-map',

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -19,7 +19,7 @@ module.exports = function getBaseConfig(config) {
     context: process.cwd(),
     output: {
       path: config.assetsPath,
-      publicPath: process.env.PUBLIC_PATH || `/${relativeAssetsPath}/`,
+      publicPath: config.assetsUrlPath,
       filename: '[name].js',
     },
     node: {

--- a/webpack/webpack.config.devServer.js
+++ b/webpack/webpack.config.devServer.js
@@ -1,21 +1,9 @@
 const path = require('path');
 
-/**
- * Transforming the public path to an relative path and check if it contains
- * space symbols. This is a workaround because publicPath can't handle a path
- * with spaces inside. This applies for unescaped as well escaped space characters.
- * On the other hand all other configured path values for the webpack dev server
- * should be absolute and can't handle an absoulte path escaped by quotation marks.
- **/
-const exceptionMsg = val => `Spaces are not allowed inside the WebPack publicPath: ${val}`;
-const testSpaces = val => { if (/\s/.test(val)) { throw new Error(exceptionMsg(val))} return val };
-const transformSlashes = val => val.replace(/\\/, '/').replace(/^\/?/, '/').replace(/\/?$/, '/');
-const relativePath = val => transformSlashes(testSpaces(path.relative(process.cwd(), val)));
-
 module.exports = function getDevServerConfig(config) {
   return {
     contentBase: config.assetsPath,
-    publicPath: relativePath(config.assetsPath),
+    publicPath: config.assetsUrlPath,
     port: 8080,
     compress: false,
     overlay: true,


### PR DESCRIPTION
This PR adds support for setting the assets path to a remote URL, e. g. in order to serve assets from a CDN.