### PR TITLE
added prefix for svg ids

### DIFF
--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -101,7 +101,7 @@ module.exports = function getBaseConfig(config) {
 
               use: {
                 loader: 'svg-inline-loader',
-                options: { removeSVGTagAttrs: false },
+                options: { removeSVGTagAttrs: false, idPrefix: true },
               },
             },
           ]


### PR DESCRIPTION
Some browsers don't scope svg tags, that are imported inline. This can lead to side effects like the usage of an mask or transformation across svg tags. This PR fixes that behavior and provide unique IDs for imported element.