### PR TITLE
update to current version, because npm audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "http-graceful-shutdown": "2.2.2",
     "morgan": "1.9.1",
     "nock": "10.0.3",
-    "node-sass": "4.9.0",
+    "node-sass": "4.12.0",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "portfinder": "1.0.17",
     "pretty-error": "2.1.1",


### PR DESCRIPTION
cryptiles (high severity) https://nvd.nist.gov/vuln/detail/CVE-2018-1000620
hoek (moderate severity) https://nvd.nist.gov/vuln/detail/CVE-2018-3728