### PR TITLE
Add content type for html

### DIFF
--- a/src/middlewares/sendHtml.js
+++ b/src/middlewares/sendHtml.js
@@ -1,6 +1,7 @@
 module.exports = function sendHtml() {
   return (req, res, next) => {
     try {
+      res.setHeader('Content-Type', 'text/html');
       res.end(res.locals.body);
     } catch (err) {
       next(err);

--- a/test/middlewares/sendHtml.test.js
+++ b/test/middlewares/sendHtml.test.js
@@ -4,8 +4,9 @@ function setup() {
   const body = '<div>test</div>';
   const locals = { body };
   const end = jest.fn();
+  const setHeader = jest.fn();
   const req = {};
-  const res = { locals, end };
+  const res = { locals, end, setHeader };
   const next = jest.fn();
   const middleware = sendHtml();
   return { body, locals, req, res, next, end, middleware };
@@ -14,6 +15,7 @@ function setup() {
 test('ends the respons with the body', () => {
   const { body, req, res, next, middleware } = setup();
   middleware(req, res, next);
+  expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
   expect(res.end).toHaveBeenCalledWith(body);
 });
 


### PR DESCRIPTION
#### What has changed and why

Before sending the HTML to the client the `Content-Type`-Header is now set to `text/html`. That is necessary for example middleware like [compression](https://github.com/expressjs/compression) to determine if the resource can be compressed or not.

#### Steps needed to ensure the issue has been resolved or how to test the feature

Run the tests
