### PR TITLE
Fix old-style webpack-merge imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vussr",
   "description": "✊ VUSSR—Server Side Rendering for VUE",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "license": "ISC",
   "main": "index.js",
   "bin": {

--- a/test/fixtures/testApp/webpack/webpack.config.client.js
+++ b/test/fixtures/testApp/webpack/webpack.config.client.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const VueSSRClientPlugin = require('vue-server-renderer/client-plugin');
 const baseConfig = require('./webpack.config.base');

--- a/test/fixtures/testApp/webpack/webpack.config.server.js
+++ b/test/fixtures/testApp/webpack/webpack.config.server.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const nodeExternals = require('webpack-node-externals');
 const VueSSRServerPlugin = require('vue-server-renderer/server-plugin');
 const baseConfig = require('./webpack.config.base');

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,4 +1,4 @@
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const client = require('./webpack.config.client');
 const server = require('./webpack.config.server');
 const devServer = require('./webpack.config.devServer');

--- a/webpack/webpack.config.client.js
+++ b/webpack/webpack.config.client.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const WebpackBar = require('webpackbar');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TerserJSPlugin = require('terser-webpack-plugin');

--- a/webpack/webpack.config.server.js
+++ b/webpack/webpack.config.server.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const nodeExternals = require('webpack-node-externals');
 const WebpackBar = require('webpackbar');
 const CopyWebpackPlugin = require('copy-webpack-plugin');


### PR DESCRIPTION
#### What has changed and why

webpack-merge was recently to upgraded to version 5 through a Dependabot PR. However, this version comes with a breaking change with regards to how the `merge` function is imported. This PR adjusts the imports accordingly.